### PR TITLE
remove logging of process list in force_kill_process_with_tree

### DIFF
--- a/lib/parallel_cucumber/helper/command.rb
+++ b/lib/parallel_cucumber/helper/command.rb
@@ -137,7 +137,6 @@ module ParallelCucumber
           unless Helper::Processes.ms_windows?
             logger << "Timeout, so trying SIGUSR1 to trigger watchdog stacktrace #{pstat[:pid]}=#{full_script}"
             Helper::Processes.kill_tree('SIGUSR1', pid, logger, tree)
-            logger << %x(ps -ax)
             sleep 2
           end
 


### PR DESCRIPTION
Don't print list of current processes when killing test batch on timeout