### PR TITLE
Fix status when test fails in after/before hooks

### DIFF
--- a/lib/parallel_cucumber/helper/cucumber.rb
+++ b/lib/parallel_cucumber/helper/cucumber.rb
@@ -34,7 +34,7 @@ module ParallelCucumber
                 background = scenario
                 next
               end
-              steps = [background['steps'], scenario['steps']].flatten.compact
+              steps = [scenario['before'], background['steps'], scenario['steps'], scenario['after']].flatten.compact
               status = case # rubocop:disable Style/EmptyCaseCondition
                        when steps.map { |step| step['result'] }.all? { |result| result['status'] == 'skipped' }
                          Status::SKIPPED


### PR DESCRIPTION
Currently, if tests fail in Before hook parallel_cucumber sets :skipped status, if in After hook :passed. It happens because we don't take into account Before/After hooks when parsing JSON results