### PR TITLE
Store selected test count(selected_test_count) in redis

### DIFF
--- a/lib/parallel_cucumber/dsl.rb
+++ b/lib/parallel_cucumber/dsl.rb
@@ -23,6 +23,10 @@ module ParallelCucumber
         Hooks.register_after_batch(proc)
       end
 
+      def before_workers(&proc)
+        Hooks.register_before_workers(proc)
+      end
+
       def after_workers(&proc)
         Hooks.register_after_workers(proc)
       end

--- a/lib/parallel_cucumber/hooks.rb
+++ b/lib/parallel_cucumber/hooks.rb
@@ -2,6 +2,7 @@ module ParallelCucumber
   class Hooks
     @before_batch_hooks ||= []
     @after_batch_hooks  ||= []
+    @before_workers     ||= []
     @after_workers      ||= []
     @on_batch_error     ||= []
 
@@ -14,6 +15,11 @@ module ParallelCucumber
       def register_after_batch(proc)
         raise(ArgumentError, 'Please provide a valid callback') unless proc.respond_to?(:call)
         @after_batch_hooks << proc
+      end
+
+      def register_before_workers(proc)
+        raise(ArgumentError, 'Please provide a valid callback') unless proc.respond_to?(:call)
+        @before_workers << proc
       end
 
       def register_after_workers(proc)
@@ -34,6 +40,12 @@ module ParallelCucumber
 
       def fire_after_batch_hooks(*args)
         @after_batch_hooks.each do |hook|
+          hook.call(*args)
+        end
+      end
+
+      def fire_before_workers(*args)
+        @before_workers.each do |hook|
           hook.call(*args)
         end
       end

--- a/lib/parallel_cucumber/main.rb
+++ b/lib/parallel_cucumber/main.rb
@@ -75,6 +75,13 @@ module ParallelCucumber
 
       status_totals = {}
       total_mm, total_ss = time_it do
+        begin
+          Hooks.fire_before_workers(queue: queue)
+        rescue StandardError => e
+          trace = e.backtrace.join("\n\t")
+          @logger.warn("There was exception in before_workers hook #{e.message} \n #{trace}")
+        end
+
         results = run_parallel_workers(number_of_workers) || {}
 
         begin


### PR DESCRIPTION
**Problem:**
- In some cases parallel_cucumber framework not generating report for executed scenario(e.g. feature scenario written in non english and executing environment doesn't support UTF8 encoding), as a result there is a mismatch between the requested test cases and reported test cases. With this, clients not aware of the missing test reports.

**Solution:**
- Enable client to know the number of test cases that parallel_cucumber executing, so that they can implement explicit validation on request/selected test case count and reported test case count.


