### PR TITLE
fire before_workers before determining number_of_workers

### DIFF
--- a/lib/parallel_cucumber/main.rb
+++ b/lib/parallel_cucumber/main.rb
@@ -37,8 +37,6 @@ module ParallelCucumber
         exit(0)
       end
 
-      count = all_tests.count
-
       long_running_tests = if @options[:long_running_tests]
                              narrowed_long_running_tests = [
                                @options[:cucumber_args],
@@ -70,18 +68,17 @@ module ParallelCucumber
 
       @logger.info("Adding #{tests.count} tests to Queue")
       queue.enqueue(tests) unless tests.empty?
+      begin
+        Hooks.fire_before_workers(queue: queue)
+      rescue StandardError => e
+        trace = e.backtrace.join("\n\t")
+        @logger.warn("There was exception in before_workers hook #{e.message} \n #{trace}")
+      end
 
-      number_of_workers = determine_work_and_batch_size(count)
+      number_of_workers = determine_work_and_batch_size(queue.length)
 
       status_totals = {}
       total_mm, total_ss = time_it do
-        begin
-          Hooks.fire_before_workers(queue: queue)
-        rescue StandardError => e
-          trace = e.backtrace.join("\n\t")
-          @logger.warn("There was exception in before_workers hook #{e.message} \n #{trace}")
-        end
-
         results = run_parallel_workers(number_of_workers) || {}
 
         begin

--- a/lib/parallel_cucumber/main.rb
+++ b/lib/parallel_cucumber/main.rb
@@ -52,6 +52,8 @@ module ParallelCucumber
       end
       tests = first_tests + (all_tests - first_tests).shuffle
 
+      collective_queue_size = 0
+
       @options[:directed_tests].each do |k, v|
         directed_tests = Helper::Cucumber.selected_tests(@options[:cucumber_options], v)
         if directed_tests.empty?
@@ -63,6 +65,7 @@ module ParallelCucumber
           @logger.info("Adding #{directed_tests.count} tests to queue _#{k}")
           directed_queue.enqueue(directed_tests)
           tests -= directed_tests
+          collective_queue_size += directed_queue.length
         end
       end
 
@@ -75,7 +78,8 @@ module ParallelCucumber
         @logger.warn("There was exception in before_workers hook #{e.message} \n #{trace}")
       end
 
-      number_of_workers = determine_work_and_batch_size(queue.length)
+      collective_queue_size += queue.length
+      number_of_workers = determine_work_and_batch_size(collective_queue_size)
 
       status_totals = {}
       total_mm, total_ss = time_it do


### PR DESCRIPTION
In before_workers, we can populate queue with more tests. This means the logic to determine the number of workers may get affected. Fixing it