### PR TITLE
[master] fix race condition when queue is empty and none of the worke…

### DIFF
--- a/lib/parallel_cucumber/worker_manager.rb
+++ b/lib/parallel_cucumber/worker_manager.rb
@@ -51,11 +51,11 @@ module ParallelCucumber
             give_job_to_healthy_worker
           elsif any_worker_busy?
             kill_surplus_workers
-            sleep 0.5
           else
             kill_all_workers
             break
           end
+          sleep 0.5
         end
       end
     end
@@ -71,6 +71,7 @@ module ParallelCucumber
     end
 
     def kill_all_workers
+      @logger.info("=== Killing All Workers")
       @workers.values.each { |w| w.assign_job(Job.new(Job::DIE)) }
     end
 


### PR DESCRIPTION
When there is just one test, very rarely, the time between worker is assigned test by manager, and just before it gets popped by the worker, the Manager thinks no worker is busy and instructs all workers to die. 
This is not a problem for a regular single run but in case of re-queue, a worker may not be available